### PR TITLE
Test Cases for member model and member list view 

### DIFF
--- a/members/templates/members/members_list.html
+++ b/members/templates/members/members_list.html
@@ -5,7 +5,7 @@
             <a class="btn btn-secondary btn-sm mt-1 mb-1" href="{% url 'member-add' %}">+</a>
         </div>
 		<h1>Team members</h1>
-		<p class="text-secondary"> You have {{members|length}} team members. </p>
+		<p class="text-secondary"> You have {{members|length}} team member{% if members|length != 1 %}s{% endif %}. </p>
 	</div>
 	{% for member in members %}
 	<div class="content-section" >

--- a/members/tests.py
+++ b/members/tests.py
@@ -73,3 +73,24 @@ class MemberListViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "You have 1 team member.")
         self.assertQuerysetEqual(response.context["members"], [member])
+
+    def test_two_regular_members(self):
+        member1 = create_member(role="Regular")
+        member1 = create_member(role="Regular")
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You have 2 team members.")
+        self.assertNotContains(response, "admin")
+        self.assertQuerysetEqual(response.context["members"], [member1, member1])
+
+    def test_two_admin_members(self):
+        member1 = create_member(role="Admin")
+        member1 = create_member(role="Admin")
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You have 2 team members.")
+        self.assertContains(response, "admin")
+        self.assertQuerysetEqual(response.context["members"], [member1, member1])
+
+
+

--- a/members/tests.py
+++ b/members/tests.py
@@ -31,3 +31,45 @@ class MemberModelTests(TestCase):
         self.assertIs(admin_member.is_admin(), False)
 
 
+def create_member(
+    f_name="test_f_name",
+    l_name="test_l_name",
+    email="test@test.com",
+    phone_number="3535351234",
+    role="regular",
+):
+    """
+    Creates a member with the given details
+    """
+    return Member.objects.create(
+        f_name=f_name, l_name=l_name, email=email, phone_number=phone_number, role=role
+    )
+
+
+class MemberListViewTests(TestCase):
+    def test_no_members(self):
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You have 0 team members.")
+        self.assertQuerysetEqual(response.context["members"], [])
+
+    def test_admin_member(self):
+        member = create_member(role="Admin")
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "admin")
+        self.assertQuerysetEqual(response.context["members"], [member])
+
+    def test_no_admin_member(self):
+        member = create_member(role="Regular")
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "admin")
+        self.assertQuerysetEqual(response.context["members"], [member])
+
+    def test_one_member(self):
+        member = create_member(role="Regular")
+        response = self.client.get(reverse("members-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You have 1 team member.")
+        self.assertQuerysetEqual(response.context["members"], [member])

--- a/members/tests.py
+++ b/members/tests.py
@@ -1,3 +1,33 @@
 from django.test import TestCase
+from django.urls import reverse
+from .models import Member
 
-# Create your tests here.
+# test cases which tests the MemberModel
+class MemberModelTests(TestCase):
+    def test_is_admin_with_admin_member(self):
+        """
+        is_admin returns true for members who are admins
+        """
+        admin_member = Member(
+            f_name="test_f_name",
+            l_name="test_l_name",
+            email="test@test.com",
+            phone_number="3234567890",
+            role="Admin",
+        )
+        self.assertIs(admin_member.is_admin(), True)
+
+    def test_is_admin_with_regular_member(self):
+        """
+        is_admin returns false for members who are not admin
+        """
+        admin_member = Member(
+            f_name="test_f_name",
+            l_name="test_l_name",
+            email="test@test.com",
+            phone_number="3234567890",
+            role="Regular",
+        )
+        self.assertIs(admin_member.is_admin(), False)
+
+


### PR DESCRIPTION
## Member model test cases
Check if is_admin returns true if member role is admin and return false if member role is regular 
## Member list view Test Cases
- Test the case with no members
- Test the case with admin member 
- Test the case where there is no admin member
- Test the case with 2 regular members
- Test the case with 2 admin members

## Changes to print team member in list page if only one member
Display "member" instead of "members" on the member list page where the count of members is displayed if there is only one member